### PR TITLE
Send custom parameters with takeOff()

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,6 +913,20 @@ $options['process']['destinations'] = ['email@mysite.com', '~jonny'];
 $options['process']['fileNames] = ['filename.png'];
 ```
 
+general custom parameters example:
+```
+$options['custom'] = [
+    [
+        'name'  => 'full_name',
+        'value' => 'John Doe',
+    ],
+    [
+        'name'  => 'age',
+        'value' => 29
+    ],
+]
+```
+
 Bee parameters that are specified require the bee name prefix. If the bee name is `xcoobee_testbee` and it requires two parameters `height` and `width` then you will need to add these into an associative array inside the parameters array with a key of bee name.
 
 ### `b` Subscriptions

--- a/src/XcooBee/Core/Api/Bees.php
+++ b/src/XcooBee/Core/Api/Bees.php
@@ -140,10 +140,14 @@ class Bees extends Api
             $params['filenames'] = $options['process']['fileNames'];
         }
 
+        if (array_key_exists('custom', $options)) {
+            $params['custom'] = $options['custom'];
+        }
+
         if ($subscriptions) {
             $params['subscriptions'] = $subscriptions;
         }
-        
+
         $destinations = array_key_exists('destinations', $options['process']) ? $options['process']['destinations'] : [];
         foreach($destinations as $key => $destination) {
             if (Validation::isValidEmail($destination)) {
@@ -157,8 +161,8 @@ class Bees extends Api
         foreach ($bees as $beeName => $beeParams) {
             if($beeName !== 'transfer'){
                 $params['bees'][] = [
-                    'bee_name'  => $beeName,
-                    'params'    => count($beeParams) ? json_encode($beeParams) : "{}",
+                    'bee_name' => $beeName,
+                    'params'   => count($beeParams) ? json_encode($beeParams) : "{}",
                 ];
             }
         }


### PR DESCRIPTION
Allow sending `custom` parameters with `takeOff()`.